### PR TITLE
Mesh 3446 validate direct address is throwing an exception when a dns server times out

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ It has not been tested (and probably won't work) in the browser environment.
 const {Validator} = require('validate-direct-address');
 
 async main() {
-  const validator = new Validator();
+   // use the default trust bundle, 1000ms timeout, 2 retries.  All options are optional
+  const validator = new Validator(undefined, 1000, 2);
 
   await validator.isValid('nonexistent@nowhere.com'); // Returns 'false' because the domain certificate does not exist
   await validator.isValid('nonexistent@direct.viacaremesh.com'); // Returns 'true' because the domain certificate exists.
-  await validator.assertValid('nonexistent@nowhere.com'); // Throws an error
+  await validator.assertValid('nonexistent@nowhere.com'); // Throws an error.  Use this or isValid based on what fits your code
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caremesh/validate-direct-address",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "This package validates that \"email\" addresses are in fact DirectTrust addresses.",
   "main": "index.js",
   "repository": "https://github.com/caremesh/validate-direct-address.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validate-direct-address",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "This package validates that \"email\" addresses are in fact DirectTrust addresses.",
   "main": "index.js",
   "repository": "https://github.com/caremesh/validate-direct-address.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@caremesh/validate-direct-address",
-  "version": "1.0.5",
+  "name": "validate-direct-address",
+  "version": "1.0.6",
   "description": "This package validates that \"email\" addresses are in fact DirectTrust addresses.",
   "main": "index.js",
   "repository": "https://github.com/caremesh/validate-direct-address.git",
@@ -20,6 +20,7 @@
     "asn1js": "^3.0.5",
     "axios": "^0.27.2",
     "bluebird": "^3.7.2",
+    "debug": "^4.3.4",
     "lodash": "^4.17.21",
     "native-node-dns": "^0.7.6",
     "pkijs": "^3.0.5"

--- a/src/validator.test.js
+++ b/src/validator.test.js
@@ -2,10 +2,10 @@ const Validator = require('./validator');
 
 describe('Validator @Validator', function() {
   let validator;
+  this.timeout(10000);
 
   before(async function() {
-    this.timeout(10000);
-    validator = new Validator();
+    validator = new Validator(undefined, 1000, 3);
   });
 
   it('Should reject a "fake" direct address @Validator.1', function(done) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,7 +287,7 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@4.3.4, debug@^4.1.1, debug@^4.3.2:
+debug@4.3.4, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==


### PR DESCRIPTION
This adds several fixes to error handling:

1) DNS timeout is now settable, and defaults to 30s instead of hard-coded to 1s.

2) We will now retry up to 3 times.

3) Previously, the error for "no such domain" was non-specific and indistinguishable for client-code from the error for "no CERT record".  Modified code so that the two errors are distinct.

4) When an error occurred that was not a domain not found or a timeout, it was not getting caught and was crashing the process.

Incrementing to version 1.1.0 as the API has changed but is backwards compatible.