### PR TITLE
Ldap-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validate-direct-address",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "This package validates that \"email\" addresses are in fact DirectTrust addresses.",
   "main": "index.js",
   "repository": "https://github.com/caremesh/validate-direct-address.git",
@@ -13,7 +13,7 @@
     "chai-string": "^1.5.0",
     "eslint": ">=5.16.0",
     "eslint-config-google": "^0.14.0",
-    "mocha": "^10.0.0",
+    "mocha": "^9.0.0",
     "mocha-cakes-2": "^3.3.0"
   },
   "dependencies": {
@@ -21,6 +21,7 @@
     "axios": "^0.27.2",
     "bluebird": "^3.7.2",
     "debug": "^4.3.4",
+    "ldapjs": "^2.3.3",
     "lodash": "^4.17.21",
     "native-node-dns": "^0.7.6",
     "pkijs": "^3.0.5"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "debug": "^4.3.4",
     "ldapjs": "^2.3.3",
     "lodash": "^4.17.21",
+    "lru-cache": "^7.14.1",
     "native-node-dns": "^0.7.6",
     "pkijs": "^3.0.5"
   },

--- a/src/ldap.js
+++ b/src/ldap.js
@@ -1,0 +1,199 @@
+/* eslint-disable new-cap */
+const Promise = require('bluebird');
+const debug = require('debug')('validate-direct-address');
+const dns = require('native-node-dns');
+const nodeDns = require('dns');
+const _ = require('lodash');
+const ldap = require('ldapjs');
+
+
+/* eslint-disable */
+function _ldapSearch(url, base='', filter='', scope='sub', attributes=null) {
+  client = ldap.createClient({
+    url: [url],
+  });
+
+
+  return new Promise((resolve, reject) => {
+    client.on('error', reject);
+
+    client.bind('', '', (err) => {
+      if (err) {
+        reject(err);
+      };
+
+      client.search(
+        base, 
+        {
+          scope,
+          filter,
+          attributes,
+        }, (error, res) => {
+          let results = [];
+   
+          if (error) {
+            debug({
+              location: `_ldapSearch#searchError`,
+              message: error.message,
+            });
+   
+            reject(error);
+          }
+   
+          res.on('searchEntry', (entry) => {
+            debug({
+              location: `_ldapSearch#searcEntry`,
+              object: entry.object
+            });
+            results.push(entry.object);
+          });
+   
+          res.on('error', (error) => {
+            debug({
+              location: `_ldapSearch#error`,
+              message: error.message,
+            });
+            reject(error);
+          });
+   
+          res.on('end', (response) => {
+            // debug({
+            //   location: `_ldapSearch#end`,
+            //   response,
+            //   results,
+            // });
+   
+            client.unbind(() => resolve(results));
+          });
+        });
+      }); 
+    });
+}
+
+/**
+ * Attempt to find an ldap server for the specified
+ * binding.
+ *
+ * @param {string} binding the domain name to lookup
+ * @param {string} address the DNS server to use
+ * @return {Promise<Array<string>>}
+ */
+function lookupServiceUrls(binding, address) {
+  if (!address) {
+    address = nodeDns.getServers()[0];
+  }
+
+  debug(`Attempting lookup for ${binding}@${address}`);
+  return new Promise((resolve, reject) => {
+    let results;
+    const question = dns.Question({
+      name: `_ldap._tcp.${binding}`,
+      type: 'SRV',
+    });
+
+    debug(`DNS Server is ${address}`);
+    const req = dns.Request({
+      question: question,
+      server: {address, port: 53, type: 'tcp'},
+      timeout: this.timeout,
+    });
+
+    req.on('timeout', (err) => {
+      debug(`Got timeout error: ${err.message}`);
+      reject(new Error(`Timeout`));
+    });
+
+    req.on('message', function(err, response) {
+      if (err) {
+        debug({
+          message: err.message,
+          stack: err.stack,
+        });
+        reject(err);
+      }
+
+      if (_.get(response, 'answer.length', 0) == 0) {
+        return null;
+      }
+
+      results = _.compact(
+          _.map(response.answer, (i) => {
+            if (_.has(i, 'target')) {
+              return `ldap://${i.target}:${i.port}`;
+            }
+          }),
+      );
+    });
+
+    req.on('error', function(error) {
+      reject(error);
+    });
+
+    req.on('end', function() {
+      resolve(results);
+    });
+
+    req.send();
+  });
+}
+
+/**
+   * Lookup a certificate for the specified direct certificate using LDAP binding
+   * and return the base64 encoded certificate.
+   *
+   * @param {string} binding the domain name to lookup
+   * @return {Promise<string>}
+   */
+async function lookup(binding) {
+  const urls = await lookupServiceUrls(binding);
+  if (_.isEmpty(urls)) {
+    debug(`Couldn't find binding for ${binding}.  This probably means that the requested binding does not exist`);
+    return undefined;
+  }
+
+  let results = await Promise.map(
+    urls,
+    async(url) => {
+      let dnList = await getBaseDnList(url);
+      debug({dnList});
+      for (let dn of dnList) {
+        let result = await _ldapSearch(url, dn, `mail=${binding}`, 'sub')
+        for (let row of result) {
+          let cert = _.get(row, 'userCertificate;binary', _.get(row, 'userCertificate'));
+          if (cert) {
+            return cert;
+          }
+        }
+      }
+    },
+  );
+
+  return _.first(results);
+}
+
+/**
+ * Get base DNS for the requested URL
+ *
+ * @param {string} url
+ * @return {Promise<string>}
+ */
+async function getBaseDnList(url) {
+  try {
+    let candidates = await _ldapSearch(url, '', 'objectclass=*', 'base', ['namingContexts']);
+    let results = _.map(candidates, 'namingContexts');
+    debug(results);
+    return results;
+  } catch(error) {
+    log.error({
+      message: error.message,
+      stack: error.stack,
+    });
+    throw(error);
+  }
+}
+
+module.exports = {
+  lookupServiceUrls,
+  lookup,
+  getBaseDnList,
+};

--- a/src/ldap.test.js
+++ b/src/ldap.test.js
@@ -1,0 +1,25 @@
+const {expect} = require('chai');
+const ldap = require('./ldap');
+const {describe, it} = require('mocha');
+
+describe('LDAP Support @ldap', function() {
+  it('should be able to get a list of LDAP service URLs @ldap.1', async function() {
+    const urls = await ldap.lookupServiceUrls('direct.ccf.org');
+    expect(urls).to.be.an('Array');
+    expect(urls).not.to.be.empty;
+    expect(urls[0]).to.match(/[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/);
+  });
+
+  it('Should be able to get the base DNs to search @ldap.2', async function() {
+    this.timeout(10000);
+    const baseDnList = await ldap.getBaseDnList('ldap://ldap.medicity.net:10389');
+    expect(baseDnList).to.be.an('array');
+    expect(baseDnList).not.to.be.empty;
+    expect(baseDnList).to.include('dc=medicity,dc=net');
+  });
+
+  it('should be able to get the certificate for an LDAP served certificate @ldap.3', async function() {
+    const certificate = await ldap.lookup(`direct.ccf.org`);
+    console.log({certificate});
+  });
+});

--- a/src/ldap.test.js
+++ b/src/ldap.test.js
@@ -19,7 +19,6 @@ describe('LDAP Support @ldap', function() {
   });
 
   it('should be able to get the certificate for an LDAP served certificate @ldap.3', async function() {
-    const certificate = await ldap.lookup(`direct.ccf.org`);
-    console.log({certificate});
+    await ldap.lookup(`direct.ccf.org`);
   });
 });

--- a/src/trust-bundle.js
+++ b/src/trust-bundle.js
@@ -46,9 +46,14 @@ module.exports = class TrustBundle {
    * @return {boolean}
    */
   async verifyCert(cert) {
-    const der = Buffer.from(cert, 'base64');
-    const ber = new Uint8Array(der).buffer;
-    const crt = pkijs.Certificate.fromBER(ber);
+    let crt;
+    try {
+      const der = Buffer.from(cert, 'base64');
+      const ber = new Uint8Array(der).buffer;
+      crt = pkijs.Certificate.fromBER(ber);
+    } catch (error) {
+      crt = pkijs.Certificate.fromBER(cert);
+    }
 
     await this.fetch();
 

--- a/src/validator.js
+++ b/src/validator.js
@@ -5,6 +5,7 @@ const dns = require('native-node-dns');
 const nodeDns = require('dns');
 const _ = require('lodash');
 const ldap = require('./ldap');
+const LRU = require('lru-cache');
 
 const TrustBundle = require('./trust-bundle');
 
@@ -18,8 +19,9 @@ module.exports = class Validator {
    * @param {number} [timeout] DNS timeout
    * @param {number} [retries] how many times to retry
    * @param {address} [address] the DNS server address to use
+   * @param {number} [maxCacheEntries] the maximum cache size in entries
    */
-  constructor(trustBundleUrl, timeout=30000, retries = 3, address = null) {
+  constructor(trustBundleUrl, timeout=30000, retries = 3, address = null, maxCacheEntries = 10000) {
     this.trustBundle = new TrustBundle(trustBundleUrl);
     this.timeout = timeout;
     this.retries = retries;
@@ -29,6 +31,10 @@ module.exports = class Validator {
       this.address = nodeDns.getServers()[0];
     }
     debug(`DNS server address is ${this.address}`);
+    this.cache = new LRU({
+      max: maxCacheEntries,
+      updateAgeOnGet: true,
+    });
   }
 
   /**
@@ -80,9 +86,13 @@ module.exports = class Validator {
       throw new Error(`Got no results for ${address}`);
     }
 
-    if ( !await this.trustBundle.verifyCert(results[0].toString('base64'))) {
-      throw new Error(`Certificate for ${address} was not signed by a HISP!`);
+    if (!this.cache.has(results[0].toString('base64'))) {
+      if ( !await this.trustBundle.verifyCert(results[0].toString('base64'))) {
+        throw new Error(`Certificate for ${address} was not signed by a HISP!`);
+      }
+      this.cache.set(results[0].toString('base64'));
     }
+
     return true;
   }
 
@@ -92,6 +102,12 @@ module.exports = class Validator {
    * @return {Promise<string>}
    */
   async _lookup(binding) {
+    const self = this;
+
+    if (this.cache.has(binding)) {
+      return this.cache.get(binding);
+    }
+
     const address = this.address;
     return await new Promise((resolve, reject) => {
       let results;
@@ -134,10 +150,12 @@ module.exports = class Validator {
           if (ldapCert) {
             ldapCert = Buffer.from(ldapCert, 'base64');
             debug({ldapCert: ldapCert.toString()});
+            self.cache.set(binding, [ldapCert]);
             resolve([ldapCert]);
           }
         }
 
+        self.cache.set(results);
         resolve(results);
       });
 

--- a/src/validator.test.js
+++ b/src/validator.test.js
@@ -36,7 +36,7 @@ describe('Validator @Validator', function() {
     expect(await validator.isValid('xample.com')).to.equal(false);
   });
 
-  it('should reject an direct addresss that\'s in an invalid format using isValid @Validator.7', async function() {
+  it('should acccept a direct addresss that\'s in a valid format using isValid @Validator.7', async function() {
     expect(await validator.isValid('patrick@direct.viacaremesh.com')).to.equal(true);
   });
 
@@ -46,6 +46,11 @@ describe('Validator @Validator', function() {
 
   it('should properly handle a direct address where the lhs has embedded periods @Validator.9', async function() {
     expect(await validator.isValid('suncoastcommunityhealthcenters.inc@suncoastchc.eclinicaldirectplus.com'))
+        .to.equal(true);
+  });
+
+  it('should properly handle a direct address managd with LDAP @Validator.10', async function() {
+    expect(await validator.isValid('jcywinski50667@direct.ccf.org'))
         .to.equal(true);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
+abstract-logging@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/abstract-logging/-/abstract-logging-2.0.1.tgz#6b0c371df212db7129b57d2e7fcf282b8bf1c839"
+  integrity sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -86,6 +91,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+asn1@^0.2.4:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
+  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
+  dependencies:
+    safer-buffer "~2.1.0"
+
 asn1js@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.5.tgz#5ea36820443dbefb51cc7f88a2ebb5b462114f38"
@@ -118,6 +130,13 @@ axios@^0.27.2:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
+backoff@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/backoff/-/backoff-2.5.0.tgz#f616eda9d3e4b66b8ca7fca79f695722c5f8e26f"
+  integrity sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==
+  dependencies:
+    precond "0.2"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -145,13 +164,6 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
-
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
-  dependencies:
-    balanced-match "^1.0.0"
 
 braces@~3.0.2:
   version "3.0.2"
@@ -287,7 +299,14 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@4.3.4, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -591,6 +610,11 @@ globals@^13.15.0:
   dependencies:
     type-fest "^0.20.2"
 
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
+  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
@@ -703,6 +727,27 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+ldap-filter@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/ldap-filter/-/ldap-filter-0.3.3.tgz#2b14c68a2a9d4104dbdbc910a1ca85fd189e9797"
+  integrity sha512-/tFkx5WIn4HuO+6w9lsfxq4FN3O+fDZeO9Mek8dCD8rTUpqzRa766BOBO7BcGkn3X86m5+cBm1/2S/Shzz7gMg==
+  dependencies:
+    assert-plus "^1.0.0"
+
+ldapjs@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/ldapjs/-/ldapjs-2.3.3.tgz#06c317d3cbb5ac42fbba741e1a8b130ffcf997ab"
+  integrity sha512-75QiiLJV/PQqtpH+HGls44dXweviFwQ6SiIK27EqzKQ5jU/7UFrl2E5nLdQ3IYRBzJ/AVFJI66u0MZ0uofKYwg==
+  dependencies:
+    abstract-logging "^2.0.0"
+    asn1 "^0.2.4"
+    assert-plus "^1.0.0"
+    backoff "^2.5.0"
+    ldap-filter "^0.3.3"
+    once "^1.4.0"
+    vasync "^2.2.0"
+    verror "^1.8.1"
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -755,12 +800,12 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
-minimatch@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
-  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+minimatch@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-4.2.1.tgz#40d9d511a46bdc4e563c22c3080cde9c0d8299b4"
+  integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
   dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^1.1.7"
 
 minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
@@ -774,30 +819,32 @@ mocha-cakes-2@^3.3.0:
   resolved "https://registry.yarnpkg.com/mocha-cakes-2/-/mocha-cakes-2-3.3.0.tgz#217ad997ed9a1e4fe8360d2e28c6c28344df58db"
   integrity sha512-VqOO4eaiPbqorwWY6H66gesvY4I/4dc/epbm/f82rHYJm4jRvAGwDJSSv6CbLlIZ76EslPEmd+aTHhUm05JbLA==
 
-mocha@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.0.0.tgz#205447d8993ec755335c4b13deba3d3a13c4def9"
-  integrity sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==
+mocha@^9.0.0:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.2.2.tgz#d70db46bdb93ca57402c809333e5a84977a88fb9"
+  integrity sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==
   dependencies:
     "@ungap/promise-all-settled" "1.1.2"
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
     chokidar "3.5.3"
-    debug "4.3.4"
+    debug "4.3.3"
     diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
     glob "7.2.0"
+    growl "1.10.5"
     he "1.2.0"
     js-yaml "4.1.0"
     log-symbols "4.1.0"
-    minimatch "5.0.1"
+    minimatch "4.2.1"
     ms "2.1.3"
-    nanoid "3.3.3"
+    nanoid "3.3.1"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"
-    workerpool "6.2.1"
+    which "2.0.2"
+    workerpool "6.2.0"
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
@@ -812,10 +859,10 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
+nanoid@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
+  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
 
 native-node-dns-cache@>=0.0.3:
   version "0.0.5"
@@ -852,7 +899,7 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -928,6 +975,11 @@ pkijs@^3.0.5:
     pvutils "^1.1.3"
     tslib "^2.4.0"
 
+precond@0.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/precond/-/precond-0.2.3.tgz#aa9591bcaa24923f1e0f4849d240f47efc1075ac"
+  integrity sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -990,6 +1042,11 @@ safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safer-buffer@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 serialize-javascript@6.0.0:
   version "6.0.0"
@@ -1091,7 +1148,23 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
-verror@^1.4.0:
+vasync@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/vasync/-/vasync-2.2.1.tgz#d881379ff3685e4affa8e775cf0fd369262a201b"
+  integrity sha512-Hq72JaTpcTFdWiNA4Y22Amej2GH3BFmBaKPPlDZ4/oC8HNn2ISHLkFrJU4Ds8R3jcUi7oo5Y9jcMHKjES+N9wQ==
+  dependencies:
+    verror "1.10.0"
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
+
+verror@^1.4.0, verror@^1.8.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.1.tgz#4bf09eeccf4563b109ed4b3d458380c972b0cdeb"
   integrity sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==
@@ -1100,7 +1173,7 @@ verror@^1.4.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-which@^2.0.1:
+which@2.0.2, which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -1112,10 +1185,10 @@ word-wrap@^1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-workerpool@6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
-  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
+workerpool@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.0.tgz#827d93c9ba23ee2019c3ffaff5c27fccea289e8b"
+  integrity sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -788,6 +788,11 @@ loupe@^2.3.1:
   dependencies:
     get-func-name "^2.0.0"
 
+lru-cache@^7.14.1:
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
+  integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"


### PR DESCRIPTION
This adds two major features:

1) LDAP certificates are now supported.
2) Results are cached for a significant performance boost.  By default, we only cache 10000.

Increment version to 2.0